### PR TITLE
Added shadow frame for header

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -117,6 +117,7 @@ header {
   height: 70px;
   padding: 0 15px;
   background: #151515;
+  z-index: 20;
 }
 
 .header__site-logo {
@@ -229,6 +230,24 @@ header {
   background-size: cover;
 
   font-size: 1em;
+}
+
+.welcome-section:after {
+  background-image: -webkit-linear-gradient(top, rgba(0,0,0,0.55), transparent);
+  background-image: -moz-linear-gradient(top, rgba(0,0,0,0.55), transparent);
+  background-image: -o-linear-gradient(top, rgba(0,0,0,0.55), transparent);
+  background-image: linear-gradient(top, rgba(0,0,0,0.55), transparent);
+  
+  height: 210px;
+}
+
+.welcome-section:after {
+  content: '';
+  left: 0;
+  top: 0;
+  position: absolute;
+  width: 100%;
+  z-index: 1;
 }
 
 .welcome-section-container {


### PR DESCRIPTION
Это популярная практика добавлять жирный теневой фон для UI компонентов поверх фона-изображения. Таким образом компоненты не сливаются с задним фоном и добавляется объемность к дизайну.
Before: ![Before](http://s.twosphere.ru/screenshots/02-01-16_19-49-25.png)
After: ![After](http://s.twosphere.ru/screenshots/02-01-16_19-50-51.png)